### PR TITLE
Correct tests for Debian releases

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -23,9 +23,9 @@ from oval.parser import wml
 ovals = {}
 
 # TODO: these may need changed or reworked.
-DEBIAN_VERSION = {"wheezy" : "7.0", "jessie" : "8.2", "stretch" : "9.0",
-                  "sid" : "9.0", "etch" : "4.0", "squeeze":"6.0", "lenny":"5.0",
-                  "woody" : "3.0", "potato" : "2.2", "sarge" : "3.1"}
+DEBIAN_VERSION = {"wheezy" : "7", "jessie" : "8", "stretch" : "9",
+                  "sid" : "9", "etch" : "4", "squeeze":"6", "lenny":"5",
+                  "woody" : "3", "potato" : "2", "sarge" : "3"}
 
 def usage (prog = "parse-wml-oval.py"):
     """Print information about script flags and options"""

--- a/oval/definition/generator.py
+++ b/oval/definition/generator.py
@@ -214,7 +214,7 @@ def __createOVALTextfilecontentState (value, operation = "equals"):
       attrs={"id":stateId, 
         "version":"1",
         "xmlns":"http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"})
-    state.appendChild ( __createXMLElement ("line", value, 
+    state.appendChild ( __createXMLElement ("subexpression", value,
                     {"operation":operation}))
     states.appendChild (state)
   
@@ -249,7 +249,7 @@ def __createTest(testType, value):
     ref = __getNewId("test")
     
     if testType == "release":
-      objectId = __createOVALTextfilecontentObject ("\d\.\d")
+      objectId = __createOVALTextfilecontentObject ("(\d)\.\d")
       comment = "Debian GNU/Linux %s is installed" % value
       
       test = __createXMLElement("textfilecontent_test", 

--- a/oval/definition/generator.py
+++ b/oval/definition/generator.py
@@ -249,7 +249,7 @@ def __createTest(testType, value):
     ref = __getNewId("test")
     
     if testType == "release":
-      objectId = __createOVALTextfilecontentObject ("(\d)\.\d")
+      objectId = __createOVALTextfilecontentObject ("(\d+)\.\d")
       comment = "Debian GNU/Linux %s is installed" % value
       
       test = __createXMLElement("textfilecontent_test", 


### PR DESCRIPTION
Previously the debian_release test was tied to a specific point
release for each release. This incorrectly narrowed the definitions.
Now we only go off the first digit for the test.

This introduces two new issues. First, the previous releases that
have the same major version number are treated the same. Second,
when we move to 10.X we will have to change it again.

This will close debian bug #860183