### PR TITLE
use Debian releases instead of years for filtering / switch to lxml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,7 @@ PYTHON=/usr/bin/python
 
 include $(WMLBASE)/Make.lang
 
-# NOTE: CUR_YEAR is defined in $(WMLBASE)/Makefile.common
-XMLFILES=$(shell for year in `seq 1997 $(CUR_YEAR)`; do echo oval-definitions-$$year.xml; done)
+XMLFILES=$(shell for release in wheezy jessie stretch; do echo oval-definitions-$$release.xml; done)
 
 XMLDESTFILES=$(patsubst %,$(HTMLDIR)/%,$(XMLFILES))
 
@@ -20,7 +19,7 @@ install:: $(XMLDESTFILES)
 
 oval-definitions-%.xml: force
 	@[ -e $(PYTHON) ] || { echo "ERROR: Required python binary $(PYTHON) is not available, aborting generation" >&2; exit 1; }
-	-$(PYTHON) generate.py -d .. -y $(patsubst oval-definitions-%.xml,%,$@) >$@
+	-$(PYTHON) generate.py -d .. -r $(patsubst oval-definitions-%.xml,%,$@) >$@
 # Warn if empty files are generated
 # Note: They cannot be removed or the install target will fail later
 	@[ -s $@ ] || echo "WARNING: OVAL Definition $@ is empty, please review script and/or DSAs" 

--- a/generate.py
+++ b/generate.py
@@ -45,6 +45,7 @@ def parsedirs (directory, regex, depth, debian_release):
   """
 
   global ovals
+  debian_version = DEBIAN_VERSION[debian_release]
 
   if depth == 0:
     logging.log(logging.DEBUG, "Maximum depth reached at directory " + directory)
@@ -78,7 +79,7 @@ def parsedirs (directory, regex, depth, debian_release):
         if wmlResult:
           data, releases = wmlResult
         # skip if the wml file does not contain the debian release
-          if not DEBIAN_VERSION[debian_release] in releases:
+          if not debian_version in releases:
               continue
           for (k, v) in data.iteritems():
             if k == "moreinfo":
@@ -93,7 +94,7 @@ def parsedirs (directory, regex, depth, debian_release):
               ovals[cve][k] = v
           if not "release" in ovals[cve]:
             ovals[cve]["release"] = {}
-          ovals[cve]['release'].update(releases)
+          ovals[cve]['release'].update({debian_version: releases[debian_version]})
 
   return 0
 
@@ -121,11 +122,10 @@ def parseJSON(json_data, debian_release):
                 else:
                     fixed_v = json_data[package][cve]['releases'][rel]['fixed_version']
                     f_str = 'yes'
-                release.update({DEBIAN_VERSION[rel]: {u'all': {
-                    package: fixed_v}}})
+                if debian_release == rel:
+                    release.update({DEBIAN_VERSION[rel]: {u'all': {
+                        package: fixed_v}}})
 
-                # print json.dumps(json_data[package][cve])
-                # sys.exit(1)
                 # filter for release which the OVAL should be generated for
                 if debian_release == rel:
                     ovals.update({cve: {"packages": package,

--- a/generate.py
+++ b/generate.py
@@ -32,14 +32,13 @@ def usage (prog = "parse-wml-oval.py"):
 
     print """usage: %s [vh] [-d <directory>]\t-d\twhich directory use for
     dsa definition search\t-v\tverbose mode\t-h\tthis help""" % prog
-
-def printdsas(ovals, year):
+def printdsas(ovals):
     """ Generate and print OVAL Definitions for collected DSA information """
 
-    ovalDefinitions = oval.definition.generator.createOVALDefinitions (ovals, year)
+    ovalDefinitions = oval.definition.generator.createOVALDefinitions (ovals)
     oval.definition.generator.printOVALDefinitions (ovalDefinitions)
 
-def parsedirs (directory, regex, depth):
+def parsedirs (directory, regex, depth, debian_release):
   """ Recursive search directory for DSA files contain postfix in their names.
 
     For this files called oval.parser.dsa.parseFile() for extracting DSA information.
@@ -59,7 +58,7 @@ def parsedirs (directory, regex, depth):
     
     if os.access(path, os.R_OK) and os.path.isdir (path) and not os.path.islink (path) and fileName[0] != '.':
       logging.log(logging.DEBUG, "Entering directory " + path)
-      parsedirs (path, regex, depth-1)
+      parsedirs (path, regex, depth-1, debian_release)
 
     #Parse fileNames
     if os.access(path, os.R_OK) and regex.search(fileName) and fileName[0] != '.' and fileName[0] != '#':
@@ -78,6 +77,9 @@ def parsedirs (directory, regex, depth):
         wmlResult = wml.parseFile(path.replace('.data', '.wml'), DEBIAN_VERSION)
         if wmlResult:
           data, releases = wmlResult
+        # skip if the wml file does not contain the debian release
+          if not DEBIAN_VERSION[debian_release] in releases:
+              continue
           for (k, v) in data.iteritems():
             if k == "moreinfo":
               if not "moreinfo" in ovals[cve]:
@@ -95,7 +97,8 @@ def parsedirs (directory, regex, depth):
 
   return 0
 
-def parseJSON(json_data, year):
+
+def parseJSON(json_data, debian_release):
     """
     Parse the JSON data and extract information needed for OVAL definitions
     :param json_data: Json_Data
@@ -123,15 +126,18 @@ def parseJSON(json_data, year):
 
                 # print json.dumps(json_data[package][cve])
                 # sys.exit(1)
-                ovals.update({cve: {"packages": package,
+                # filter for release which the OVAL should be generated for
+                if debian_release == rel:
+                    ovals.update({cve: {"packages": package,
                                         'title': cve,
                                         'vulnerable': "yes",
                                         'date': str(today.isoformat()),
-                                        'fixed': f_str, 
-                                        'description': json_data[package][cve].get("description",""),
+                                        'fixed': f_str,
+                                        'description': json_data[package][cve].get("description", ""),
                                         'secrefs': cve,
                                         'release': release}})
-                logging.log(logging.DEBUG, "Created entry for %s" % cve)
+                    logging.log(logging.DEBUG, "Created entry for %s" % cve)
+
 
 def get_json_data(json_file):
     """
@@ -162,7 +168,7 @@ def main(args):
     json_file = args['JSONfile']
     data_dir = args['data_directory']
     temp_file = args['tmp']
-    year = args['year']
+    release = args['release']
 
     if json_file:
         json_data = get_json_data(json_file)
@@ -183,11 +189,11 @@ def main(args):
             logging.log(logging.DEBUG, "Removing file %s" % temp_file)
             os.remove(temp_file)
 
-    parseJSON(json_data, year)
-    parsedirs(data_dir, re.compile('^dsa.+\.data$'), 2)
-    parsedirs(data_dir, re.compile('^dla.+\.data$'), 2)
+    parseJSON(json_data, release)
+    parsedirs(data_dir, re.compile('^dsa.+\.data$'), 2, release)
+    parsedirs(data_dir, re.compile('^dla.+\.data$'), 2, release)
     logging.log(logging.INFO, "Finished parsing JSON data")
-    printdsas(ovals, year)
+    printdsas(ovals)
 
 if __name__ == "__main__":
     PARSER = argparse.ArgumentParser(description='Generates oval definitions '
@@ -208,8 +214,8 @@ if __name__ == "__main__":
                              ' if this file already exists it will be removed '
                              'prior to downloading the JSON file. default= '
                              './DebSecTrackTMP.t', default='./DebSecTrackTMP.t')
-    PARSER.add_argument('-y', '--year', type=str,
-                        help='Limit to this year. default= ' '2016', default='2016')
+    PARSER.add_argument('-r', '--release', type=str,
+                        help='Limit to this release. default= jessie', default='jessie')
     PARSER.add_argument('-i', '--id', type=int,
                         help='id number to start defintions at. default=100',
                         default=100)


### PR DESCRIPTION
this PR:
#### * changes the filter logic from per-year to per-release
per default (Makefile) ovals will be generated for
* wheezy
* jessie
* stretch

#### * uses lxml instead of minidom for performance reasons
when testing the former change, memory leaks manifested, which were caused by minidom.
by using lxml instead of minidom, up to 80-90% memory are saved (there is probably more potential for optimization).

Benchmarks:
```
minidom:
4378.883 MiB 4116.801 MiB         definitions.appendChild (createDefinition(cve, ovals[cve]))
lxml:
663.395 MiB  430.199 MiB         definitions.append(createDefinition(cve, ovals[cve]))
```

Note: This adds a dependency for `python-lxml`